### PR TITLE
Fix "wait for all" not resolving when given empty list of promises

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13,8 +13,7 @@ Ignored Vars: O, f, args, x, cb
 </pre>
 
 <pre class="link-defaults">
-spec:infra; type:dfn;
-    text:list
+spec:infra; type:dfn; text:list
 </pre>
 
 <pre class="anchors">

--- a/index.bs
+++ b/index.bs
@@ -269,6 +269,7 @@ To <dfn id="waiting-for-all" export lt="wait for all|waiting for all">wait for a
 1. Let |index| be 0.
 1. Let |total| be |promises|'s [=list/size=].
 1. Let |result| be a <a>list</a> containing |total| null values.
+1. If |total| is 0, then perform |successSteps| given |result| and abort these steps.
 1. [=list/For each=] |promise| of |promises|:
     1. Let |promiseIndex| be |index|.
     1. Let |fulfillmentHandler| be a built-in function that takes an argument |arg| performs the following steps:

--- a/index.bs
+++ b/index.bs
@@ -13,7 +13,10 @@ Ignored Vars: O, f, args, x, cb
 </pre>
 
 <pre class="link-defaults">
-spec:infra; type:dfn; text:list
+spec:infra; type:dfn;
+    text:list
+spec:html; type:dfn;
+    text:queue a microtask
 </pre>
 
 <pre class="anchors">
@@ -269,7 +272,9 @@ To <dfn id="waiting-for-all" export lt="wait for all|waiting for all">wait for a
 1. Let |index| be 0.
 1. Let |total| be |promises|'s [=list/size=].
 1. Let |result| be a <a>list</a> containing |total| null values.
-1. If |total| is 0, then perform |successSteps| given |result| and abort these steps.
+1. If |total| is 0, then:
+    1. <a>Queue a microtask</a> to perform |successSteps| given |result|.
+    1. Return.
 1. [=list/For each=] |promise| of |promises|:
     1. Let |promiseIndex| be |index|.
     1. Let |fulfillmentHandler| be a built-in function that takes an argument |arg| performs the following steps:

--- a/index.bs
+++ b/index.bs
@@ -15,8 +15,6 @@ Ignored Vars: O, f, args, x, cb
 <pre class="link-defaults">
 spec:infra; type:dfn;
     text:list
-spec:html; type:dfn;
-    text:queue a microtask
 </pre>
 
 <pre class="anchors">


### PR DESCRIPTION
From [my comment](https://github.com/whatwg/streams/issues/1004#issuecomment-511037767) on whatwg/streams#1004:
> The steps in the "wait for all" algorithm do not account for the case where _promises_ is an empty list! It attaches a _fulfillmentHandler_ to every promise in _promises_, and checks whether we're done **only inside that handler**. But if no promises were passed in, then no handlers are attached and we never check whether we're done.
>
> The fix is obvious: if the list of promises passed to the "wait for all" algorithm is empty, then it should immediately call _successSteps_ with an empty list.